### PR TITLE
Set the correct FFmpeg encoder for AMD hardware

### DIFF
--- a/VideoNodes/FfmpegBuilderNodes/Video/FfmpegBuilderVideoEncode.cs
+++ b/VideoNodes/FfmpegBuilderNodes/Video/FfmpegBuilderVideoEncode.cs
@@ -195,7 +195,7 @@ public class FfmpegBuilderVideoEncode:FfmpegBuilderNode
         stream.EncodingParameters.Clear();
         stream.EncodingParameters.AddRange(new[]
         {
-            h265 ? "amf_nvenc" : "amf_nvenc",
+            h265 ? "hevc_amf" : "hevc_amf",
             "-rc", "constqp",
             "-qp", Quality.ToString(),
             //"-b:v", "0K", // this would do a two-pass... slower
@@ -212,7 +212,7 @@ public class FfmpegBuilderVideoEncode:FfmpegBuilderNode
         stream.EncodingParameters.Clear();
         stream.EncodingParameters.AddRange(new[]
         {
-            h265 ? "amf_nvenc" : "amf_nvenc",
+            h265 ? "hevc_amf" : "hevc_amf",
             "-rc", "constqp",
             "-qp", Quality.ToString(),
             //"-b:v", "0K", // this would do a two-pass... slower


### PR DESCRIPTION
INFO -> Unknown encoder 'amf_nvenc'
This would show in logs with HW encoding enabled when running with AMD GPU. Provided changes should cse the correct  encoder

Replaced amf_nvenc with hevc_amf in FfmpegBuilderVideoEncode.cs

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
