### PR TITLE
Add keep parent option to delete source folder *UNTESTED*

### DIFF
--- a/BasicNodes/BasicNodes.en.json
+++ b/BasicNodes/BasicNodes.en.json
@@ -50,7 +50,9 @@
             "IfEmpty": "If Empty",
             "IfEmpty-Help": "Only delete the source folder if the it is empty",
             "IncludePatterns": "Include Patterns",
-            "IncludePatterns-Help": "Optional, if set only files matching these patterns will be counted to see if the folder is empty.   Any of these patterns can match."
+            "IncludePatterns-Help": "Optional, if set only files matching these patterns will be counted to see if the folder is empty.   Any of these patterns can match.",
+            "KeepParents": "Keep parent folders",
+            "KeepParents-Help": "Optional, if set parent folders will not be removed.\nThis only includes the folders inside of your library"
           }
         },
         "Executor": {

--- a/BasicNodes/File/DeleteSourceDirectory.cs
+++ b/BasicNodes/File/DeleteSourceDirectory.cs
@@ -19,6 +19,9 @@ namespace FileFlows.BasicNodes.File
         [StringArray(2)]
         public string[] IncludePatterns { get; set; }
 
+        [Boolean(3)]
+        public bool KeepParents { get; set; }
+
         public override int Execute(NodeParameters args)
         {
             string path = args.FileName.Substring(0, args.FileName.Length - args.RelativeFile.Length);
@@ -41,7 +44,7 @@ namespace FileFlows.BasicNodes.File
                 if (IfEmpty)
                 {
                     string libFilePath = args.IsDirectory ? args.FileName : new FileInfo(args.FileName).DirectoryName;
-                    return RecursiveDelete(args, path, libFilePath, true);
+                    return RecursiveDelete(args, path, libFilePath, true, KeepParents);
                 }
 
 
@@ -56,7 +59,7 @@ namespace FileFlows.BasicNodes.File
             return base.Execute(args);
         }
 
-        private int RecursiveDelete(NodeParameters args, string root, string path, bool deleteSubFolders)
+        private int RecursiveDelete(NodeParameters args, string root, string path, bool deleteSubFolders, bool KeepParents)
         {
             args.Logger?.ILog("Checking directory to delete: " + path);
             DirectoryInfo dir = new DirectoryInfo(path);
@@ -117,7 +120,13 @@ namespace FileFlows.BasicNodes.File
                 return dir.Exists ? 2 : 1; // silenty fail
             }
 
-            return RecursiveDelete(args, root, dir.Parent.FullName, false);
+            if (KeepParents == true)
+            {
+                args.Logger?.ILog("Keeping parent folders, stopping deleting: " + root);
+                return 1;
+            }
+
+            return RecursiveDelete(args, root, dir.Parent.FullName, false, false);
         }
     }
 }


### PR DESCRIPTION
**UNTESTED**

I figured if I did 90% of the work you'd be much more likely too agree. As you know I have been messing around with *arr and getting series packs / albums too work properly with man in the middle. To do this I have to actually make a middle stage, otherwise when 75% of the files have been transcoded *arr will pick up half the folder.

[Using this guide as a reference](https://fileflows.com/docs/guides/sonarr-radarr)

We path map complete to converted, so to stop sonarr picking up the files until they are all done I put the files in `/converted/_unpack/`, when the source folder is empty (aka it's done encoding) then I can move that folder back into `/converted`

"Remove source folder" should return 1... However it returns 2 unless the library root is empty (which if there is a queue it will never be), not just the source folder.  

This proposed change should add an option to keep the parent folders ignoring everything accept the source folder and returning 1 if that is removed and 2 if it is not.

*Flow*

Folder with 1 or more files downloads too `/complete/download1` 
File flows processes it and moves the file  `/converted/_unpack/download1`
If we successfully remove `/completed/download1` even if `/complete/download2` is still in the queue
Then we move folder `/converted/_unpack/download1` to `/converted/download1`

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
