### PR TITLE
feature(subtitles): add hearing impaired

### DIFF
--- a/VideoNodes/FfmpegBuilderNodes/Models/FfmpegModel.cs
+++ b/VideoNodes/FfmpegBuilderNodes/Models/FfmpegModel.cs
@@ -132,6 +132,7 @@
                     Stream = item.stream,
                     IsDefault = item.stream.Default,
                     IsForced = item.stream.Forced,
+                    IsHearingImpaired = item.stream.HearingImpaired,
                     Codec = item.stream.Codec
                 });
             }

--- a/VideoNodes/FfmpegBuilderNodes/Models/FfmpegSubtitleStream.cs
+++ b/VideoNodes/FfmpegBuilderNodes/Models/FfmpegSubtitleStream.cs
@@ -15,6 +15,11 @@ public class FfmpegSubtitleStream : FfmpegStream
     public bool IsForced { get; set; }
 
     /// <summary>
+    /// Gets or sets if this is a Hearing Impaired subtitle
+    /// </summary>
+    public bool IsHearingImpaired { get; set; }
+
+    /// <summary>
     /// Gets or sets if this stream has changed
     /// </summary>
     public override bool HasChange => false;
@@ -81,6 +86,8 @@ public class FfmpegSubtitleStream : FfmpegStream
             results.AddRange(new[] { "-disposition:s:" + args.OutputTypeIndex, "default" });
         else if(this.IsForced)
             results.AddRange(new[] { "-disposition:s:" + args.OutputTypeIndex, "forced" });
+        else if(this.IsHearingImpaired)
+            results.AddRange(new[] { "-disposition:s:" + args.OutputTypeIndex, "hearing_impaired" });
         else
             results.AddRange(new[] { "-disposition:s:" + args.OutputTypeIndex, "0" });
 
@@ -106,6 +113,7 @@ public class FfmpegSubtitleStream : FfmpegStream
             Title,
             IsDefault ? "Default" : null,
             Stream?.Forced == true ? "Forced" : null,
+            Stream?.HearingImpaired == true ? "Hearing Impaired" : null,
             Deleted ? "Deleted" : null,
             HasChange ? "Changed" : null
         }.Where(x => string.IsNullOrWhiteSpace(x) == false));

--- a/VideoNodes/VideoInfo.cs
+++ b/VideoNodes/VideoInfo.cs
@@ -241,6 +241,11 @@ public class SubtitleStream : VideoFileStream
     public bool Default { get; set; }
 
     /// <summary>
+    /// If this is a hearing impaired subtitle
+    /// </summary>
+    public bool HearingImpaired { get; set; }
+
+    /// <summary>
     /// Converts the steam to a string
     /// </summary>
     /// <returns></returns>

--- a/VideoNodes/VideoInfoHelper.cs
+++ b/VideoNodes/VideoInfoHelper.cs
@@ -416,7 +416,7 @@ public class VideoInfoHelper
     }
     public static SubtitleStream ParseSubtitleStream(string info)
     {
-        // Stream #0:1(eng): Audio: dts (DTS), 48000 Hz, stereo, fltp, 1536 kb/s (default)
+        // Stream #0:1(eng): Subtitle: subrip (srt) (default) (forced)
         string line = info.Split(new string[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries).First();
         var parts = line.Split(",").Select(x => x?.Trim() ?? "").ToArray();
         SubtitleStream sub = new SubtitleStream();
@@ -431,6 +431,7 @@ public class VideoInfoHelper
             sub.Title = rgxTitle.Match(info).Value.Trim();
 
         sub.Forced = info.ToLower().Contains("(forced)");
+        sub.HearingImpaired = info.ToLower().Contains("(hearing impaired)");
         return sub;
     }
     

--- a/VideoNodes/VideoNodes/VideoNode.cs
+++ b/VideoNodes/VideoNodes/VideoNode.cs
@@ -196,6 +196,8 @@ namespace FileFlows.VideoNodes
                     metadata.Add(prefix + "Default", true);
                 if(stream.Forced)
                     metadata.Add(prefix + "Forced", true);
+                if (stream.HearingImpaired)
+                    metadata.Add(prefix + "Hearing Impaired", true);
             }
 
             string extension = FileHelper.GetExtension(videoInfo.FileName).ToLowerInvariant()[1..]; 

--- a/VideoNodes/i18n/de.json
+++ b/VideoNodes/i18n/de.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Ob die Untertiteldatei nach dem Zusammenführen gelöscht werden soll",
           "Forced": "Erzwingend",
           "Forced-Help": "Ob der Untertitel erzwungen werden soll",
+          "HearingImpaired": "Hörgeschädigt",
+          "HearingImpaired-Help": "Ob der Untertitel für Hörgeschädigte sein soll",
           "Language": "Sprache",
           "Language-Help": "Optionaler [ISO 639-2](https://de.wikipedia.org/wiki/Liste_der_ISO_639-2-Codes) Sprachcode für den hinzugefügten Untertitel.",
           "MatchFilename": "Dateiname abgleichen",

--- a/VideoNodes/i18n/en.json
+++ b/VideoNodes/i18n/en.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "If the subtitle file should be deleted after being merged",
           "Forced": "Forced",
           "Forced-Help": "If the subtitle should be forced",
+          "HearingImpaired": "Hearing Impaired",
+          "HearingImpaired-Help": "If the subtitle should be marked as hearing impaired",
           "Language": "Language",
           "Language-Help": "Optional [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) language code for the added subtitle.",
           "MatchFilename": "Match Filename",

--- a/VideoNodes/i18n/es.json
+++ b/VideoNodes/i18n/es.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Si el archivo de subtítulos debe ser eliminado después de ser fusionado",
           "Forced": "Forzado",
           "Forced-Help": "Si el subtítulo debe ser forzado",
+          "HearingImpaired": "Audición Impedida",
+          "HearingImpaired-Help": "Si el subtítulo debe ser para audición impedida",
           "Language": "Idioma",
           "Language-Help": "Código de idioma opcional [ISO 639-2](https://es.wikipedia.org/wiki/Anexo:C%C3%B3digos_ISO_639-2) para el subtítulo añadido.",
           "MatchFilename": "Coincidir Nombre de Archivo",

--- a/VideoNodes/i18n/fr.json
+++ b/VideoNodes/i18n/fr.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Si le fichier de sous-titres doit être supprimé après avoir été fusionné",
           "Forced": "Forcé",
           "Forced-Help": "Si le sous-titre doit être forcé",
+          "HearingImpaired": "Malentendant",
+          "HearingImpaired-Help": "Si le sous-titre est destiné aux malentendants",
           "Language": "Langue",
           "Language-Help": "Code de langue optionnel [ISO 639-2](https://fr.wikipedia.org/wiki/ISO_639-2) pour le sous-titre ajouté.",
           "MatchFilename": "Correspondre au Nom de Fichier",

--- a/VideoNodes/i18n/it.json
+++ b/VideoNodes/i18n/it.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Se il file dei sottotitoli deve essere eliminato dopo essere stato unito",
           "Forced": "Forzato",
           "Forced-Help": "Se il sottotitolo deve essere forzato",
+          "HearingImpaired": "Udito Difettoso",
+          "HearingImpaired-Help": "Se il sottotitolo è per persone con problemi di udito",
           "Language": "Lingua",
           "Language-Help": "Codice lingua [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) opzionale per il sottotitolo aggiunto.",
           "MatchFilename": "Corrispondi Nome File",

--- a/VideoNodes/i18n/ja.json
+++ b/VideoNodes/i18n/ja.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "マージ後に字幕ファイルを削除するかどうか",
           "Forced": "強制",
           "Forced-Help": "字幕を強制するかどうか",
+          "HearingImpaired": "聴覚障害者向け",
+          "HearingImpaired-Help": "字幕を聴覚障害者向けにするかどうか",
           "Language": "言語",
           "Language-Help": "追加された字幕のオプションの[ISO 639-2](https://ja.wikipedia.org/wiki/ISO_639-2)言語コード。",
           "MatchFilename": "ファイル名を一致させる",

--- a/VideoNodes/i18n/ko.json
+++ b/VideoNodes/i18n/ko.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "병합 후 자막 파일을 삭제해야 하는지 여부",
           "Forced": "강제",
           "Forced-Help": "자막이 강제되어야 하는지 여부",
+          "HearingImpaired": "청각 장애인",
+          "HearingImpaired-Help": "자막이 청각 장애인을 위한 자막이어야 하는지 여부",
           "Language": "언어",
           "Language-Help": "추가된 자막에 대한 선택적 [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) 언어 코드.",
           "MatchFilename": "파일명 일치",

--- a/VideoNodes/i18n/nl.json
+++ b/VideoNodes/i18n/nl.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Als het ondertitelbestand moet worden verwijderd na het samenvoegen",
           "Forced": "Gedwongen",
           "Forced-Help": "Als de ondertitel gedwongen moet worden",
+          "HearingImpaired": "Slechthorend",
+          "HearingImpaired-Help": "Als de ondertitel voor slechthorenden is",
           "Language": "Taal",
           "Language-Help": "Optionele [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) taalcodes voor de toegevoegde ondertitel.",
           "MatchFilename": "Bestandsnaam Matchen",

--- a/VideoNodes/i18n/pt.json
+++ b/VideoNodes/i18n/pt.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Se o arquivo de legenda deve ser excluído após ser mesclado",
           "Forced": "Forçado",
           "Forced-Help": "Se a legenda deve ser forçada",
+          "HearingImpaired": "Deficiência Auditiva",
+          "HearingImpaired-Help": "Se a legenda deve ser marcada como deficiência auditiva",
           "Language": "Idioma",
           "Language-Help": "Código de idioma opcional [ISO 639-2](https://pt.wikipedia.org/wiki/ISO_639-2) para a legenda adicionada.",
           "MatchFilename": "Correspondência de Nome de Arquivo",

--- a/VideoNodes/i18n/ru.json
+++ b/VideoNodes/i18n/ru.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Если файл субтитров должен быть удалён после объединения",
           "Forced": "Принудительно",
           "Forced-Help": "Если субтитр должен быть принудительным",
+          "HearingImpaired": "Слабослышащие",
+          "HearingImpaired-Help": "Если субтитр должен быть помечен как слабослышащий",
           "Language": "Язык",
           "Language-Help": "Необязательный [код языка ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) для добавленного субтитра.",
           "MatchFilename": "Совпадение имени файла",

--- a/VideoNodes/i18n/sv.json
+++ b/VideoNodes/i18n/sv.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "Om undertextfilen ska tas bort efter att ha slagits samman",
           "Forced": "Tvingad",
           "Forced-Help": "Om undertexten ska vara tvingad",
+          "HearingImpaired": "Hörselskadad",
+          "HearingImpaired-Help": "Om undertexten ska vara för hörselskadade",
           "Language": "Språk",
           "Language-Help": "Valfri [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) språk kod för den tillagda undertexten.",
           "MatchFilename": "Matcha filnamn",

--- a/VideoNodes/i18n/zh.json
+++ b/VideoNodes/i18n/zh.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "如果字幕文件在合并后应被删除",
           "Forced": "强制",
           "Forced-Help": "如果字幕应被强制",
+          "HearingImpaired": "听障",
+          "HearingImpaired-Help": "如果字幕应被标记为听障",
           "Language": "语言",
           "Language-Help": "添加字幕的可选[ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)语言代码。",
           "MatchFilename": "匹配文件名",

--- a/VideoNodes/i18n/zht.json
+++ b/VideoNodes/i18n/zht.json
@@ -707,6 +707,8 @@
           "DeleteAfterwards-Help": "如果字幕文件在合併後應被刪除",
           "Forced": "強制",
           "Forced-Help": "如果字幕應該是強制的",
+          "HearingImpaired": "聽力障礙",
+          "HearingImpaired-Help": "如果字幕應該是聽力障礙字幕",
           "Language": "語言",
           "Language-Help": "添加字幕的可選 [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) 語言代碼。",
           "MatchFilename": "匹配檔名",


### PR DESCRIPTION
This pull request adds management of the hearing impaired flag for subtitles so that this flag can be managed in the various plugins like the forced flag. 

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
